### PR TITLE
Correct outdated `forceFetch` in `apollo-angular` pagination recipe

### DIFF
--- a/docs/source/recipes/pagination.md
+++ b/docs/source/recipes/pagination.md
@@ -51,7 +51,7 @@ class FeedComponent implements OnInit {
         offset: 0,
         limit: this.itemsPerPage,
       },
-      forceFetch: true,
+      fetchPolicy: 'network-only',
     });
 
     this.feed = this.feedQuery


### PR DESCRIPTION
`forceFetch` has been replaced with `fetchPolicy: 'network-only'` since ApolloClient 1.0:
https://s3.amazonaws.com/apollo-docs-1.x/migration.html#fetchPolicy

<!--
  Thanks for filing a pull request on Apollo Angular!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Angular is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - GitHub Actions will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

### Checklist:

- [ ] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Try to include the Pull Request inside of CHANGELOG.md
