### PR TITLE
docs(developer-tooling): Add info about deprecated apollo-codegen lib

### DIFF
--- a/docs/source/features/developer-tooling.md
+++ b/docs/source/features/developer-tooling.md
@@ -51,7 +51,7 @@ See [Apollo iOS](https://github.com/apollographql/apollo-ios) for details on the
 
 ### Usage
 
-##### Note: This and the sections below of this documentation are outdated. `apollo-codegen` is now deprecated, and you should use [`apollo`](https://www.npmjs.com/package/apollo#code-generation) instead.
+##### Note: This and the sections below of this documentation are outdated. `apollo-codegen` is now deprecated. Try using [`apollo`](https://www.npmjs.com/package/apollo#code-generation) or [`graphql-code-generator`](https://graphql-code-generator.com/) instead for GQL code generation.
 
 If you want to use `apollo-codegen`, you can install it command globally:
 

--- a/docs/source/features/developer-tooling.md
+++ b/docs/source/features/developer-tooling.md
@@ -51,6 +51,8 @@ See [Apollo iOS](https://github.com/apollographql/apollo-ios) for details on the
 
 ### Usage
 
+##### Note: This and the sections below of this documentation are outdated. `apollo-codegen` is now deprecated, and you should use [`apollo`](https://www.npmjs.com/package/apollo#code-generation) instead.
+
 If you want to use `apollo-codegen`, you can install it command globally:
 
 ```bash


### PR DESCRIPTION
To avoid people spending time on outdated libs. (apollo-codegen isn't maintained for 2 years now)