### PR TITLE
docs(network-layer) Add missing import from apollo-link

### DIFF
--- a/docs/source/basics/network-layer.md
+++ b/docs/source/basics/network-layer.md
@@ -145,7 +145,7 @@ The following example shows the use of multiple middlewares passed as an array:
 ```ts
 import { Apollo } from 'apollo-angular';
 import { HttpLink } from 'apollo-angular-link-http';
-import { ApolloLink } from 'apollo-link';
+import { ApolloLink, from } from 'apollo-link';
 
 @NgModule({ ... })
 class AppModule {


### PR DESCRIPTION
adds missing `from` import for multiple middleware example.

### Checklist:

- [x] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [ ] Try to include the Pull Request inside of CHANGELOG.md
