### PR TITLE
Replace `get` with `inject`

### DIFF
--- a/website/docs/development-and-testing/testing.md
+++ b/website/docs/development-and-testing/testing.md
@@ -94,7 +94,7 @@ describe('DogComponent', () => {
       imports: [ApolloTestingModule],
     });
 
-    controller = TestBed.get(ApolloTestingController);
+    controller = TestBed.inject(ApolloTestingController);
   });
 
   afterEach(() => {
@@ -208,7 +208,7 @@ describe('DogComponent', () => {
       imports: [ApolloTestingModule.withClients(['clientA', 'clientB'])],
     });
 
-    controller = TestBed.get(ApolloTestingController);
+    controller = TestBed.inject(ApolloTestingController);
   });
 
   afterEach(() => {


### PR DESCRIPTION
`Testbed.get` has been [deprecated](https://angular.io/api/core/testing/TestBed#get) since Angular 9.0