### PR TITLE
Issue 1580 - expose get current result

### DIFF
--- a/packages/apollo-angular/src/query-ref.ts
+++ b/packages/apollo-angular/src/query-ref.ts
@@ -1,5 +1,6 @@
 import {NgZone} from '@angular/core';
 import {
+  ApolloCurrentQueryResult,
   ApolloQueryResult,
   ObservableQuery,
   ApolloError,
@@ -44,6 +45,10 @@ export class QueryRef<T, V = EmptyObject> {
 
   public result(): Promise<ApolloQueryResult<T>> {
     return this.obsQuery.result();
+  }
+
+  public getCurrentResult(): ApolloCurrentQueryResult<T> {
+    return this.obsQuery.getCurrentResult();
   }
 
   public getLastResult(): ApolloQueryResult<T> {

--- a/packages/apollo-angular/tests/QueryRef.spec.ts
+++ b/packages/apollo-angular/tests/QueryRef.spec.ts
@@ -166,6 +166,33 @@ describe('QueryRef', () => {
     expect(mockCallback.mock.calls.length).toBe(1);
   });
 
+  test('should be able to call getCurrentResult() and get updated results', (done) => {
+    let calls = 0;
+    const obs = queryRef.valueChanges;
+
+    obs.pipe(map((result: any) => result.data)).subscribe({
+      next: (result: any) => {
+        calls++;
+        const currentResult = queryRef.getCurrentResult();
+        expect(currentResult.data.heroes.length).toBe(result.heroes.length);
+
+        if (calls === 2) {
+          done();
+        }
+      },
+      error: (e: any) => {
+        done.fail(e);
+      },
+      complete: () => {
+        done.fail('Should not be here');
+      },
+    });
+
+    setTimeout(() => {
+      queryRef.refetch();
+    }, 200);
+  });
+
   test('should be able to call getLastResult()', () => {
     const mockCallback = jest.fn();
     obsQuery.getLastResult = mockCallback.mockReturnValue('expected');


### PR DESCRIPTION
currentResult was removed in Apollo v3 and replaced by getCurrentResult. In apollo-angular v1, currentResult() method was exposed.
This pull request is to expose the getCurrentResult method in QueryRef.