### PR TITLE
Correct WebSocketLink URI in Subscriptions docs

### DIFF
--- a/website/docs/data/subscriptions.md
+++ b/website/docs/data/subscriptions.md
@@ -64,7 +64,7 @@ Let's look at how to add support for this transport to Apollo Client.
 import {WebSocketLink} from '@apollo/client/link/ws';
 
 const wsClient = new WebSocketLink({
-  uri: `ws://localhost:5000/`,
+  uri: `ws://localhost:5000/graphql`,
   options: {
     reconnect: true,
   },
@@ -241,7 +241,7 @@ In many cases it is necessary to authenticate clients before allowing them to re
 import {WebSocketLink} from 'apollo-link-ws';
 
 const wsLink = new WebSocketLink({
-  uri: `ws://localhost:5000/`,
+  uri: `ws://localhost:5000/graphql`,
   options: {
     reconnect: true,
     connectionParams: {


### PR DESCRIPTION
Without appending the `graphql` path, I get the following error connecting to `apollo-server-express@2.18.2`:

```
WebSocket connection to 'ws://localhost:5000/' failed: Error during WebSocket handshake: Unexpected response code: 400
```

### Checklist:

- [ ] If this PR is a new feature, please reference a discussion where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Try to include the Pull Request inside of CHANGELOG.md
