### PR TITLE
feat: strip unncessary characters from the query

### DIFF
--- a/packages/apollo-angular/CHANGELOG.md
+++ b/packages/apollo-angular/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### vNext
 
 - Fixes [#1594](https://github.com/kamilkisiela/apollo-angular/issues/1594)
+- feat: strip unncessary characters from the query [#1630](https://github.com/kamilkisiela/apollo-angular/pull/1630)
 
 ### v2.1.0
 

--- a/packages/apollo-angular/http/src/http-link.ts
+++ b/packages/apollo-angular/http/src/http-link.ts
@@ -6,7 +6,7 @@ import {
   Operation,
   FetchResult,
 } from '@apollo/client/core';
-import {print} from 'graphql';
+import {print, stripIgnoredCharacters} from 'graphql';
 import {extractFiles} from 'extract-files';
 import {Options, Body, Request, Context} from './types';
 import {
@@ -63,7 +63,9 @@ export class HttpLinkHandler extends ApolloLink {
         }
 
         if (includeQuery) {
-          (req.body as Body).query = print(operation.query);
+          (req.body as Body).query = stripIgnoredCharacters(
+            print(operation.query),
+          );
         }
 
         const headers = createHeadersWithClientAwereness(context);

--- a/packages/apollo-angular/http/tests/http-link.spec.ts
+++ b/packages/apollo-angular/http/tests/http-link.spec.ts
@@ -206,6 +206,39 @@ describe('HttpLink', () => {
     });
   });
 
+  test('if it includes the query it should strip unused characters from the query', () => {
+    const link = httpLink.create({
+      uri: 'graphql',
+      method: 'GET',
+      includeQuery: true,
+    });
+    const op = {
+      query: gql`
+        query heroes {
+          heroes {
+            name
+          }
+        }
+      `,
+      operationName: 'heroes',
+      variables: {up: 'dog'},
+      extensions: {what: 'what'},
+    };
+
+    execute(link, op).subscribe(noop);
+
+    httpBackend.match((req) => {
+      expect(req.method).toBe('GET');
+      expect(req.urlWithParams).not.toEqual(
+        'graphql?operationName=heroes&variables=%7B%22up%22:%22dog%22%7D&query=query%20heroes%20%7B%0A%20%20heroes%20%7B%0A%20%20%20%20name%0A%20%20%7D%0A%7D%0A',
+      );
+      expect(req.urlWithParams).toEqual(
+        'graphql?operationName=heroes&variables=%7B%22up%22:%22dog%22%7D&query=query%20heroes%7Bheroes%7Bname%7D%7D',
+      );
+      return true;
+    });
+  });
+
   test('should include extensions if allowed', () => {
     const link = httpLink.create({
       uri: 'graphql',


### PR DESCRIPTION
See: https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers

This came up in https://github.com/graycoreio/daffodil when trying to send GraphQl queries as GET (for caching reasons with the GraphQL API of the ecommerce system Magento 2).

The deeper a query became, the more `%20` characters were added to the URL, which eventually overflowed Chrome's (and various other browser's) max URL length.

This strips the useless characters out, reduces bandwidth consumption, and saves us all from some painful edge-cases.

### Checklist:

- [x] If this PR is a new feature, please reference a discussion where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Try to include the Pull Request inside of CHANGELOG.md
