### PR TITLE
Fix: Use let in Apollo constructor due to firefox bug

### DIFF
--- a/packages/apollo-angular/CHANGELOG.md
+++ b/packages/apollo-angular/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### vNext
 
 - Fixes [#1594](https://github.com/kamilkisiela/apollo-angular/issues/1594)
+- Fix: Use let in Apollo constructor due to firefox bug
 
 ### v2.1.0
 

--- a/packages/apollo-angular/src/apollo.ts
+++ b/packages/apollo-angular/src/apollo.ts
@@ -158,7 +158,7 @@ export class Apollo extends ApolloBase<any> {
     }
 
     if (apolloNamedOptions && typeof apolloNamedOptions === 'object') {
-      for (const name in apolloNamedOptions) {
+      for (let name in apolloNamedOptions) {
         if (apolloNamedOptions.hasOwnProperty(name)) {
           const options = apolloNamedOptions[name];
           this.createNamed(name, options);


### PR DESCRIPTION
Source: https://stackoverflow.com/questions/39044803/syntaxerror-missing-in-const-declaration-firefox-50
Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1101653
In my case build breaks in firefox 52, this is the medcine.

### Checklist:

- [x] If this PR is a new feature, please reference a discussion where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Try to include the Pull Request inside of CHANGELOG.md
