### PR TITLE
Fixed the overlapping menu button in mobile devices

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -59,3 +59,7 @@ html[data-theme='dark'] .DocSearch {
     var(--ifm-color-emphasis-100) 100%
   );
 }
+
+.menu button {
+  margin-bottom: 70px;
+}


### PR DESCRIPTION
This PR is to fix the overlap between bottom menu button and chat button as seen in the screenshot for mobile devices.

![image](https://user-images.githubusercontent.com/1165845/115200509-ee550f80-a111-11eb-978b-d4b249c71b1d.png)
