### PR TITLE
Fix "NullInjectorError: No provider for TransferState!" for ssr example

### DIFF
--- a/website/docs/performance/server-side-rendering.md
+++ b/website/docs/performance/server-side-rendering.md
@@ -29,6 +29,7 @@ const APOLLO_CACHE = new InjectionToken<InMemoryCache>('apollo-cache');
   imports: [
     // ...
     BrowserModule,
+    BrowserTransferStateModule,
     ApolloModule,
     HttpClientModule,
   ],


### PR DESCRIPTION
This fixed a browser console error when executing the SSR example from the docs:
![Screen Shot 2021-04-26 at 15 22 12](https://user-images.githubusercontent.com/4541640/116090040-c03c7600-a6a3-11eb-8afd-246b9f5a7b23.png)

`BrowserTransferStateModule` is imported in the app module, but not included in the imports array.

Not sure if this is worth an entry in the the changelog?

### Checklist:

- [ x ] If this PR is a new feature, please reference a discussion where a consensus about the design was reached (not necessary for small changes)
- [ x ] Make sure all of the significant new logic is covered by tests
- [ x ] Try to include the Pull Request inside of CHANGELOG.md
