### PR TITLE
Declare Angular 12 support

### DIFF
--- a/packages/apollo-angular/CHANGELOG.md
+++ b/packages/apollo-angular/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Typed `gql` and `graphql` tags - both accept two generic types and support `TypedDocumentNode` [`9a8ea5f`](https://github.com/kamilkisiela/apollo-angular/commit/9a8ea5f229cf7937d74332092cb3eba40828b7b1)
 - Add `useMutationLoading` flag [`bc223fe`](https://github.com/kamilkisiela/apollo-angular/commit/bc223fe6487edd35c56ad908e4739580ce69f056)
 - Fix type inference for Mutations [#1659](https://github.com/kamilkisiela/apollo-angular/pull/1659)
+- Declare support for Angular 12
 
 ### v2.4.0
 

--- a/packages/apollo-angular/package.json
+++ b/packages/apollo-angular/package.json
@@ -34,11 +34,11 @@
     "deploy:next": "yarn build && npm publish build --tag next"
   },
   "peerDependencies": {
-    "@angular/core": "^6.1.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+    "@angular/core": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
     "@apollo/client": "^3.0.0",
-    "graphql": ">=0.11.0 <0.14.0 || ^14.0.0 || ^15.0.0",
+    "graphql": "^14.0.0 || ^15.0.0",
     "rxjs": "^6.0.0",
-    "zone.js": ">=0.8.0 <0.12.0"
+    "zone.js": ">=0.10.0 <0.12.0"
   },
   "dependencies": {
     "semver": "^7.0.0",


### PR DESCRIPTION
This also drops older Angular versions that are not officially
supported anymore according to:
https://angular.io/guide/releases#support-policy-and-schedule

And it also align other dependencies that still allowed obsoletes
versions.

Fixes #1669

### Checklist:

- [ ] If this PR is a new feature, please reference a discussion where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Try to include the Pull Request inside of CHANGELOG.md
