### PR TITLE
fix: create default client if named client is named default

### DIFF
--- a/packages/apollo-angular/CHANGELOG.md
+++ b/packages/apollo-angular/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNext
 
+- Fix creating default client when using named options (`APOLLO_NAMED_OPTIONS`)
+
 ### v4.1.0
 
 - Support `@apollo/client` v3.7.X

--- a/packages/apollo-angular/src/apollo.ts
+++ b/packages/apollo-angular/src/apollo.ts
@@ -142,7 +142,7 @@ export class Apollo extends ApolloBase<any> {
       for (let name in apolloNamedOptions) {
         if (apolloNamedOptions.hasOwnProperty(name)) {
           const options = apolloNamedOptions[name];
-          this.createNamed(name, options);
+          this.create(options, name);
         }
       }
     }

--- a/packages/apollo-angular/tests/Apollo.spec.ts
+++ b/packages/apollo-angular/tests/Apollo.spec.ts
@@ -1007,6 +1007,22 @@ describe('Apollo', () => {
       });
   });
 
+  test('should create default client with named options', () => {
+    const apollo = new Apollo(ngZone, undefined, {
+      default: {
+        link: mockSingleLink(),
+        cache: new InMemoryCache(),
+      },
+      test: {
+        link: mockSingleLink(),
+        cache: new InMemoryCache(),
+      },
+    });
+
+    expect(apollo.client).toBeDefined();
+    expect(apollo.use('test').client).toBeDefined();
+  });
+
   test('should remove default client', () => {
     const apollo = mockApollo(mockSingleLink(), ngZone);
 


### PR DESCRIPTION
### Checklist:

- [x] If this PR is a new feature, please reference a discussion where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all the significant new logic is covered by tests
- [x] Try to include the Pull Request inside of CHANGELOG.md

I was following the documentation about [multiple clients](https://www.the-guild.dev/graphql/apollo-angular/docs/recipes/multiple-clients#creating-clients-using-apollo_named_options), I encountered an error stating `Client has not been defined yet`.

The documentation states that if you have a named option `default`, it will be the default client. That does not work.

Currently, if you provide options for a `default` client through `APOLLO_NAMED_OPTIONS`, it creates a "named client" named `default`. Accessing it is not possible because the actual default client is not set, and using `use('default')` results in the default client.

This fixes that. The test added fails without the fix.