### PR TITLE
let TVariable generics extend OperationVariables

### DIFF
--- a/.changeset/gorgeous-coats-shave.md
+++ b/.changeset/gorgeous-coats-shave.md
@@ -1,5 +1,5 @@
 ---
-'apollo-angular': minor
+'apollo-angular': patch
 ---
 
 `TVariable` generics now `extend OperationVariables` to accommodate an upstream type change in @apollo/client@3.7.6. #1910, #1907

--- a/.changeset/gorgeous-coats-shave.md
+++ b/.changeset/gorgeous-coats-shave.md
@@ -1,0 +1,5 @@
+---
+'apollo-angular': minor
+---
+
+`TVariable` generics now `extend OperationVariables` to accommodate an upstream type change in @apollo/client@3.7.6. #1910, #1907

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@angular/platform-browser-dynamic": "^14.0.6",
     "@angular/platform-server": "^14.0.6",
     "@angular/router": "^14.0.6",
-    "@apollo/client": "3.7.5",
+    "@apollo/client": "3.7.7",
     "@babel/core": "^7.17.4",
     "@babel/preset-env": "^7.16.11",
     "@schematics/angular": "^14.0.6",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@angular/platform-browser-dynamic": "^14.0.6",
     "@angular/platform-server": "^14.0.6",
     "@angular/router": "^14.0.6",
-    "@apollo/client": "3.7.7",
+    "@apollo/client": "^3.7.7",
     "@babel/core": "^7.17.4",
     "@babel/preset-env": "^7.16.11",
     "@schematics/angular": "^14.0.6",

--- a/packages/apollo-angular/src/apollo.ts
+++ b/packages/apollo-angular/src/apollo.ts
@@ -6,6 +6,7 @@ import type {
   ApolloClientOptions,
   ObservableQuery,
   FetchResult,
+  OperationVariables,
 } from '@apollo/client/core';
 import { ApolloClient } from '@apollo/client/core';
 import { Observable, from } from 'rxjs';
@@ -32,7 +33,7 @@ export class ApolloBase<TCacheShape = any> {
     this.useMutationLoading = pickFlag(flags, 'useMutationLoading', false);
   }
 
-  public watchQuery<TData, TVariables = EmptyObject>(
+  public watchQuery<TData, TVariables extends OperationVariables = EmptyObject>(
     options: WatchQueryOptions<TVariables, TData>
   ): QueryRef<TData, TVariables> {
     return new QueryRef<TData, TVariables>(

--- a/packages/apollo-angular/src/query-ref.ts
+++ b/packages/apollo-angular/src/query-ref.ts
@@ -7,6 +7,7 @@ import type {
   SubscribeToMoreOptions,
   UpdateQueryOptions,
   TypedDocumentNode,
+  OperationVariables,
 } from '@apollo/client/core';
 import {NetworkStatus} from '@apollo/client/core';
 import {Observable, from} from 'rxjs';
@@ -14,7 +15,7 @@ import {Observable, from} from 'rxjs';
 import {wrapWithZone, fixObservable} from './utils';
 import {WatchQueryOptions, EmptyObject} from './types';
 
-function useInitialLoading<T, V>(obsQuery: ObservableQuery<T, V>) {
+function useInitialLoading<T, V extends OperationVariables>(obsQuery: ObservableQuery<T, V>) {
   return function useInitialLoadingOperator<T>(
     source: Observable<T>,
   ): Observable<T> {
@@ -45,10 +46,11 @@ function useInitialLoading<T, V>(obsQuery: ObservableQuery<T, V>) {
   };
 }
 
-export type QueryRefFromDocument<T extends TypedDocumentNode> =
-  T extends TypedDocumentNode<infer R, infer V> ? QueryRef<R, V> : never;
+export type QueryRefFromDocument<T extends TypedDocumentNode> = T extends TypedDocumentNode<infer R, infer V>
+  ? QueryRef<R, V & OperationVariables>
+  : never;
 
-export class QueryRef<T, V = EmptyObject> {
+export class QueryRef<T, V extends OperationVariables = EmptyObject> {
   public valueChanges: Observable<ApolloQueryResult<T>>;
   public queryId: ObservableQuery<T, V>['queryId'];
 

--- a/packages/apollo-angular/src/query.ts
+++ b/packages/apollo-angular/src/query.ts
@@ -1,6 +1,6 @@
 import {Injectable} from '@angular/core';
 import type {DocumentNode} from 'graphql';
-import type {ApolloQueryResult, TypedDocumentNode} from '@apollo/client/core';
+import type { ApolloQueryResult, TypedDocumentNode, OperationVariables } from '@apollo/client/core';
 import type {Observable} from 'rxjs';
 
 import {Apollo} from './apollo';
@@ -8,7 +8,7 @@ import {QueryRef} from './query-ref';
 import {WatchQueryOptionsAlone, QueryOptionsAlone, EmptyObject} from './types';
 
 @Injectable()
-export class Query<T = {}, V = EmptyObject> {
+export class Query<T = {}, V extends OperationVariables = EmptyObject> {
   public readonly document: DocumentNode | TypedDocumentNode<T, V>;
   public client = 'default';
 

--- a/packages/apollo-angular/src/types.ts
+++ b/packages/apollo-angular/src/types.ts
@@ -6,6 +6,7 @@ import type {
   ApolloClientOptions,
   FetchResult,
   TypedDocumentNode,
+  OperationVariables,
 } from '@apollo/client/core';
 import type { ExecutionResult } from 'graphql';
 
@@ -26,7 +27,7 @@ export type MutationResult<TData = any> = FetchResult<TData> & {
 
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
-export interface WatchQueryOptionsAlone<TVariables = EmptyObject, TData = any>
+export interface WatchQueryOptionsAlone<TVariables extends OperationVariables = EmptyObject, TData = any>
   extends Omit<WatchQueryOptions<TVariables, TData>, 'query' | 'variables'> {}
 
 export interface QueryOptionsAlone<TVariables = EmptyObject, TData = any>
@@ -38,7 +39,7 @@ export interface MutationOptionsAlone<TData = EmptyObject, TVariables = any>
 export interface SubscriptionOptionsAlone<TVariables = EmptyObject, TData = any>
   extends Omit<CoreSubscriptionOptions<TVariables, TData>, 'query' | 'variables'> {}
 
-export interface WatchQueryOptions<TVariables = EmptyObject, TData = any>
+export interface WatchQueryOptions<TVariables extends OperationVariables = EmptyObject, TData = any>
   extends CoreWatchQueryOptions<TVariables, TData> {
   /**
    * Observable starts with `{ loading: true }`.

--- a/yarn.lock
+++ b/yarn.lock
@@ -489,10 +489,10 @@
   dependencies:
     tslib "^2.3.0"
 
-"@apollo/client@3.7.5":
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.7.5.tgz#d2ab6e284822296c9102ff57ab3a8dcbaa818052"
-  integrity sha512-HEAhX2n2Y8Y2BwRr0UdteT94OTM7pn64K5/rTk/oLIdg/h7R2d83LdsCGDxSH5sBiqDqlv9vou4xdyTxxRWj/g==
+"@apollo/client@3.7.7":
+  version "3.7.7"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.7.7.tgz#5eb6e8af24fb809c97c8f66c3faf9524f83c412b"
+  integrity sha512-Rp/pCWuJSjLN7Xl5Qi2NoeURmZYEU/TIUz0n/LOwEo1tGdU2W7/fGVZ8+5um58JeVYq4UoTGBKFxSVeG4s411A==
   dependencies:
     "@graphql-typed-document-node/core" "^3.1.1"
     "@wry/context" "^0.7.0"


### PR DESCRIPTION
to accommodate an upstream type change in @apollo/client@3.7.6

This addresses https://github.com/kamilkisiela/apollo-angular/issues/1907

### Checklist:

- [ ] If this PR is a new feature, please reference a discussion where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all the significant new logic is covered by tests
- [x] Try to include the Pull Request inside of CHANGELOG.md
