### PR TITLE
Do not aggregate GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ jobs:
   stable:
     uses: the-guild-org/shared-config/.github/workflows/release-stable.yml@main
     with:
+      createGithubReleases: true
       releaseScript: release
       nodeVersion: 16
     secrets:


### PR DESCRIPTION
Because we only have a single package
