### PR TITLE
Demonstrate usage of ApolloLink.from with onError

### DIFF
--- a/website/src/pages/docs/data/error-handling.mdx
+++ b/website/src/pages/docs/data/error-handling.mdx
@@ -84,7 +84,28 @@ object containing the following keys:
 - `graphQLErrors`: An array of errors from the GraphQL endpoint
 - `networkError`: any error during the link execution or server response
 
-Ignoring errors
+### Using the error link
+
+To incoporate the error link into the apollo client,
+it must be combined with other links using `ApolloLink.from({...})`:
+
+```ts
+import { onError } from '@apollo/client/link/error';
+import { ApolloLink } from '@apollo/client/core';
+import { HttpLink } from 'apollo-angular/http';
+
+const httpLink = new HttpLink({
+  uri: 'http://localhost:8080/graphql'
+});
+const errorLink = onError(({...}) => {...});
+
+apollo.create({
+  link: ApolloLink.from([errorLink, httpLink]),
+  cache: new InMemoryCache(),
+});
+```
+
+### Ignoring errors
 
 If you want to conditionally ignore errors, you can set `response.errors = null` within the error
 handler:


### PR DESCRIPTION
I couldn't figure out how to do this without consulting Stack Overflow (https://stackoverflow.com/questions/49420667/angular-apollo-error-handling).  I figured it merited a quick doc update.

### Checklist:

- [N/A] If this PR is a new feature, please reference a discussion where a consensus about the design
      was reached (not necessary for small changes)
- [N/A] Make sure all the significant new logic is covered by tests
