### PR TITLE
Disable dev-tool check when using ApolloTestingModule

### DIFF
--- a/.changeset/unlucky-falcons-breathe.md
+++ b/.changeset/unlucky-falcons-breathe.md
@@ -1,0 +1,5 @@
+---
+'apollo-angular': patch
+---
+
+Disable dev-tool check when using ApolloTestingModule

--- a/packages/apollo-angular/testing/src/module.ts
+++ b/packages/apollo-angular/testing/src/module.ts
@@ -53,6 +53,7 @@ export class ApolloTestingModuleCore {
   ) {
     function createOptions(name: string, c?: ApolloCache<any> | null) {
       return {
+        connectToDevTools: false,
         link: new ApolloLink(operation => backend.handle(addClient(name, operation))),
         cache:
           c ||


### PR DESCRIPTION
closes https://github.com/kamilkisiela/apollo-angular/issues/2072
