### PR TITLE
include information about connectToDevTools

### DIFF
--- a/website/src/pages/docs/performance/server-side-rendering.mdx
+++ b/website/src/pages/docs/performance/server-side-rendering.mdx
@@ -174,6 +174,32 @@ apollo.create({
 });
 ```
 
+## Using Apollo DevTools
+
+The current Apollo client implementation supports a chrome dev tools plugin for troubleshooting
+queries. When using Apollo with SSR in a development environment, the attempts to connect to the
+plugin can cause the server to hang for about 10s.
+
+To avoid this, you can set the `connectToDevTools` option to `false` as below:
+
+```ts
+...
+useFactory(...) {
+  ...
+  return {
+    ....
+    connectToDevTools: false
+  };
+},
+
+// Or when creating the client
+
+apollo.create({
+  ...
+  connectToDevTools: false
+})
+```
+
 ## Best Practices
 
 You saw how to use Server-Side Rendering and Store Rehydration in your application, but you will

--- a/website/src/pages/docs/performance/server-side-rendering.mdx
+++ b/website/src/pages/docs/performance/server-side-rendering.mdx
@@ -183,20 +183,21 @@ plugin can cause the server to hang for about 10s.
 To avoid this, you can set the `connectToDevTools` option to `false` as below:
 
 ```ts
-...
-useFactory(...) {
-  ...
-  return {
-    ....
-    connectToDevTools: false
-  };
+// When providing options
+{
+  provide: APOLLO_OPTIONS,
+  useFactory: () {
+    return {
+      connectToDevTools: false
+      // ...
+    };
+  },
 },
 
 // Or when creating the client
-
 apollo.create({
-  ...
   connectToDevTools: false
+  // ...
 })
 ```
 


### PR DESCRIPTION
Adds information about the Apollo client development tools that can cause SSR to hang.

investigation stemming from [this comment on this issue](https://github.com/kamilkisiela/apollo-angular/issues/1698#issuecomment-1999620273)

### Checklist:

- [x] If this PR is a new feature, please reference a discussion where a consensus about the design
      was reached (not necessary for small changes)
- [x] Make sure all the significant new logic is covered by tests

