### PR TITLE
Use Typescript strict mode

### DIFF
--- a/.changeset/chilly-spiders-protect.md
+++ b/.changeset/chilly-spiders-protect.md
@@ -1,0 +1,26 @@
+---
+"apollo-angular": major
+---
+
+BREAKING use Typescript strict mode
+
+This is breaking because:
+
+- `ApolloBase.client` throws an error if no client has been created
+  beforehand. The behavior now matches the typing that always declared a
+  client existed. In most cases, you should pass either `apolloOptions`
+  or `apolloNamedOptions` to `Apollo.constructor` to create the
+  client immediately upon construction.
+- `ApolloBase.query()`, `ApolloBase.mutate()` and
+  `ApolloBase.subscribe()` all have a new constraint on `V`. If you
+  inherit from this class, you might need to adjust your typing.
+- Classes that inherit `Query`, `Mutation` and `Subscription` must
+  declare the `document` member. This requirement always existed at
+  runtime but was not enforced at compile time until now. If you generated
+  code, you have nothing to do.
+- `QueryRef.getLastResult()` and `QueryRef.getLastError()` might return
+  `undefined`. This was always the case, but was typed incorrectly until
+  now.
+- `pickFlag()` was dropped without any replacement.
+- `createPersistedQueryLink()` requires options. This was always the
+  case but was typed incorrectly until now.

--- a/.changeset/chilly-spiders-protect.md
+++ b/.changeset/chilly-spiders-protect.md
@@ -1,26 +1,22 @@
 ---
-"apollo-angular": major
+'apollo-angular': major
 ---
 
 BREAKING use Typescript strict mode
 
 This is breaking because:
 
-- `ApolloBase.client` throws an error if no client has been created
-  beforehand. The behavior now matches the typing that always declared a
-  client existed. In most cases, you should pass either `apolloOptions`
-  or `apolloNamedOptions` to `Apollo.constructor` to create the
-  client immediately upon construction.
-- `ApolloBase.query()`, `ApolloBase.mutate()` and
-  `ApolloBase.subscribe()` all have a new constraint on `V`. If you
-  inherit from this class, you might need to adjust your typing.
-- Classes that inherit `Query`, `Mutation` and `Subscription` must
-  declare the `document` member. This requirement always existed at
-  runtime but was not enforced at compile time until now. If you generated
-  code, you have nothing to do.
-- `QueryRef.getLastResult()` and `QueryRef.getLastError()` might return
-  `undefined`. This was always the case, but was typed incorrectly until
-  now.
+- `ApolloBase.client` throws an error if no client has been created beforehand. The behavior now
+  matches the typing that always declared a client existed. In most cases, you should pass either
+  `apolloOptions` or `apolloNamedOptions` to `Apollo.constructor` to create the client immediately
+  upon construction.
+- `ApolloBase.query()`, `ApolloBase.mutate()` and `ApolloBase.subscribe()` all have a new constraint
+  on `V`. If you inherit from this class, you might need to adjust your typing.
+- Classes that inherit `Query`, `Mutation` and `Subscription` must declare the `document` member.
+  This requirement always existed at runtime but was not enforced at compile time until now. If you
+  generated code, you have nothing to do.
+- `QueryRef.getLastResult()` and `QueryRef.getLastError()` might return `undefined`. This was always
+  the case, but was typed incorrectly until now.
 - `pickFlag()` was dropped without any replacement.
-- `createPersistedQueryLink()` requires options. This was always the
-  case but was typed incorrectly until now.
+- `createPersistedQueryLink()` requires options. This was always the case but was typed incorrectly
+  until now.

--- a/packages/apollo-angular/http/src/http-link.ts
+++ b/packages/apollo-angular/http/src/http-link.ts
@@ -7,8 +7,9 @@ import {
   Observable as LinkObservable,
   Operation,
 } from '@apollo/client/core';
+import { pick } from './http-batch-link';
 import { Body, Context, OperationPrinter, Options, Request } from './types';
-import { createHeadersWithClientAwareness, fetch, mergeHeaders, prioritize } from './utils';
+import { createHeadersWithClientAwareness, fetch, mergeHeaders } from './utils';
 
 // XXX find a better name for it
 export class HttpLinkHandler extends ApolloLink {
@@ -29,20 +30,12 @@ export class HttpLinkHandler extends ApolloLink {
       new LinkObservable((observer: any) => {
         const context: Context = operation.getContext();
 
-        // decides which value to pick, Context, Options or to just use the default
-        const pick = <K extends keyof Context>(
-          key: K,
-          init?: Context[K] | Options[K],
-        ): Context[K] | Options[K] => {
-          return prioritize(context[key], this.options[key], init);
-        };
-
-        let method = pick('method', 'POST');
-        const includeQuery = pick('includeQuery', true);
-        const includeExtensions = pick('includeExtensions', false);
-        const url = pick('uri', 'graphql');
-        const withCredentials = pick('withCredentials');
-        const useMultipart = pick('useMultipart');
+        let method = pick(context, this.options, 'method');
+        const includeQuery = pick(context, this.options, 'includeQuery');
+        const includeExtensions = pick(context, this.options, 'includeExtensions');
+        const url = pick(context, this.options, 'uri');
+        const withCredentials = pick(context, this.options, 'withCredentials');
+        const useMultipart = pick(context, this.options, 'useMultipart');
         const useGETForQueries = this.options.useGETForQueries === true;
 
         const isQuery = operation.query.definitions.some(

--- a/packages/apollo-angular/http/src/utils.ts
+++ b/packages/apollo-angular/http/src/utils.ts
@@ -109,11 +109,14 @@ export const fetch = (
   });
 };
 
-export const mergeHeaders = (source: HttpHeaders, destination: HttpHeaders): HttpHeaders => {
+export const mergeHeaders = (
+  source: HttpHeaders | undefined,
+  destination: HttpHeaders,
+): HttpHeaders => {
   if (source && destination) {
     const merged = destination
       .keys()
-      .reduce((headers, name) => headers.set(name, destination.getAll(name)), source);
+      .reduce((headers, name) => headers.set(name, destination.getAll(name)!), source);
 
     return merged;
   }
@@ -121,14 +124,10 @@ export const mergeHeaders = (source: HttpHeaders, destination: HttpHeaders): Htt
   return destination || source;
 };
 
-export function prioritize<T>(...values: T[]): T {
-  const picked = values.find(val => typeof val !== 'undefined');
-
-  if (typeof picked === 'undefined') {
-    return values[values.length - 1];
-  }
-
-  return picked;
+export function prioritize<T>(
+  ...values: [NonNullable<T>, ...T[]] | [...T[], NonNullable<T>]
+): NonNullable<T> {
+  return values.find(val => typeof val !== 'undefined') as NonNullable<T>;
 }
 
 export function createHeadersWithClientAwareness(context: Record<string, any>) {

--- a/packages/apollo-angular/persisted-queries/src/index.ts
+++ b/packages/apollo-angular/persisted-queries/src/index.ts
@@ -19,5 +19,5 @@ const transformLink = setContext((_, context) => {
   return ctx;
 });
 
-export const createPersistedQueryLink = (options?: Options) =>
+export const createPersistedQueryLink = (options: Options) =>
   ApolloLink.from([_createPersistedQueryLink(options), transformLink as any]);

--- a/packages/apollo-angular/persisted-queries/tests/persisted-queries.spec.ts
+++ b/packages/apollo-angular/persisted-queries/tests/persisted-queries.spec.ts
@@ -1,4 +1,4 @@
-import { ApolloLink, execute, gql, Observable, Operation } from '@apollo/client/core';
+import { ApolloLink, execute, FetchResult, gql, Observable, Operation } from '@apollo/client/core';
 import { createPersistedQueryLink } from '../src';
 
 const query = gql`
@@ -23,7 +23,7 @@ class MockLink extends ApolloLink {
   }
 
   public request(operation: Operation) {
-    return new Observable(observer => {
+    return new Observable<FetchResult>(observer => {
       const request: any = {};
 
       if (operation.getContext().includeQuery) {

--- a/packages/apollo-angular/schematics/install/index.ts
+++ b/packages/apollo-angular/schematics/install/index.ts
@@ -74,7 +74,7 @@ function addDependencies(options: Schema): Rule {
 function includeAsyncIterableLib(): Rule {
   const requiredLib = 'esnext.asynciterable';
 
-  function updateFn(tsconfig: any) {
+  function updateFn(tsconfig: any): boolean {
     const compilerOptions: CompilerOptions = tsconfig.compilerOptions;
 
     if (
@@ -85,6 +85,8 @@ function includeAsyncIterableLib(): Rule {
       compilerOptions.lib.push(requiredLib);
       return true;
     }
+
+    return false;
   }
 
   return (host: Tree) => {
@@ -127,7 +129,7 @@ function updateTSConfig(
 }
 
 function allowSyntheticDefaultImports(): Rule {
-  function updateFn(tsconfig: any) {
+  function updateFn(tsconfig: any): boolean {
     if (
       tsconfig?.compilerOptions &&
       tsconfig?.compilerOptions?.lib &&
@@ -136,6 +138,8 @@ function allowSyntheticDefaultImports(): Rule {
       tsconfig.compilerOptions.allowSyntheticDefaultImports = true;
       return true;
     }
+
+    return false;
   }
 
   return (host: Tree) => {

--- a/packages/apollo-angular/schematics/install/schema.ts
+++ b/packages/apollo-angular/schematics/install/schema.ts
@@ -1,6 +1,6 @@
 export interface Schema {
   /** Name of the project to target. */
-  project?: string;
+  project: string;
   /** Url to your GraphQL endpoint */
   endpoint?: string;
   /** Version of GraphQL (16 by default) */

--- a/packages/apollo-angular/schematics/tests/ng-add.spec.ts
+++ b/packages/apollo-angular/schematics/tests/ng-add.spec.ts
@@ -18,6 +18,7 @@ describe('ng-add with module', () => {
     const { dependencies } = packageJson;
 
     const dependenciesMap = createDependenciesMap({
+      project: 'my-project',
       graphql: '16',
     });
 
@@ -72,6 +73,7 @@ describe('ng-add with standalone', () => {
     const { dependencies } = packageJson;
 
     const dependenciesMap = createDependenciesMap({
+      project: 'my-project',
       graphql: '16',
     });
 

--- a/packages/apollo-angular/schematics/utils/ast.ts
+++ b/packages/apollo-angular/schematics/utils/ast.ts
@@ -17,7 +17,7 @@ export async function addModuleImportToRootModule(
   host: Tree,
   importedModuleName: string,
   importedModulePath: string,
-  projectName?: string,
+  projectName: string,
 ) {
   const mainPath = await getMainFilePath(host, projectName);
   if (isStandaloneApp(host, mainPath)) {
@@ -67,7 +67,7 @@ function addModuleImportToModule(
   }
 
   changes
-    .filter((change: Change) => change instanceof InsertChange)
+    .filter((change: Change): change is InsertChange => change instanceof InsertChange)
     .forEach((change: InsertChange) => recorder.insertLeft(change.pos, change.toAdd));
 
   host.commitUpdate(recorder);
@@ -98,7 +98,7 @@ function _addSymbolToNgModuleMetadata(
   const matchingProperties: ts.ObjectLiteralElement[] = (
     node as ts.ObjectLiteralExpression
   ).properties
-    .filter(prop => prop.kind == ts.SyntaxKind.PropertyAssignment)
+    .filter((prop): prop is ts.PropertyAssignment => prop.kind == ts.SyntaxKind.PropertyAssignment)
     // Filter out every fields that's not "metadataField". Also handles string literals
     // (but not expressions).
     .filter((prop: ts.PropertyAssignment) => {
@@ -218,7 +218,7 @@ function getDecoratorMetadata(
     source,
     ts.SyntaxKind.ImportDeclaration,
   )
-    .map((node: ts.ImportDeclaration) => _angularImportsFromNode(node, source))
+    .map(node => _angularImportsFromNode(node as ts.ImportDeclaration, source))
     .reduce((acc: { [name: string]: string }, current: { [name: string]: string }) => {
       for (const key of Object.keys(current)) {
         acc[key] = current[key];
@@ -418,7 +418,7 @@ export function insertImport(
 
   // no such import declaration exists
   const useStrict = findNodes(rootNode, ts.SyntaxKind.StringLiteral).filter(
-    (n: ts.StringLiteral) => n.text === 'use strict',
+    n => (n as ts.StringLiteral).text === 'use strict',
   );
   let fallbackPos = 0;
   if (useStrict.length > 0) {

--- a/packages/apollo-angular/src/apollo.ts
+++ b/packages/apollo-angular/src/apollo.ts
@@ -77,25 +77,6 @@ export class ApolloBase<TCacheShape = any> {
 
   /**
    * Get an instance of ApolloClient
-   * @deprecated use `apollo.client` instead
-   */
-  public getClient() {
-    return this.client;
-  }
-
-  /**
-   * Set a new instance of ApolloClient
-   * Remember to clean up the store before setting a new client.
-   * @deprecated use `apollo.client = client` instead
-   *
-   * @param client ApolloClient instance
-   */
-  public setClient(client: ApolloClient<TCacheShape>) {
-    this.client = client;
-  }
-
-  /**
-   * Get an instance of ApolloClient
    */
   public get client(): ApolloClient<TCacheShape> {
     return this.ensureClient();

--- a/packages/apollo-angular/src/mutation.ts
+++ b/packages/apollo-angular/src/mutation.ts
@@ -1,13 +1,13 @@
 import type { DocumentNode } from 'graphql';
 import type { Observable } from 'rxjs';
 import { Injectable } from '@angular/core';
-import type { TypedDocumentNode } from '@apollo/client/core';
+import type { OperationVariables, TypedDocumentNode } from '@apollo/client/core';
 import { Apollo } from './apollo';
 import type { EmptyObject, MutationOptionsAlone, MutationResult } from './types';
 
 @Injectable()
-export class Mutation<T = {}, V = EmptyObject> {
-  public readonly document: DocumentNode | TypedDocumentNode<T, V>;
+export abstract class Mutation<T = {}, V extends OperationVariables = EmptyObject> {
+  public abstract readonly document: DocumentNode | TypedDocumentNode<T, V>;
   public client = 'default';
 
   constructor(protected apollo: Apollo) {}

--- a/packages/apollo-angular/src/query-ref.ts
+++ b/packages/apollo-angular/src/query-ref.ts
@@ -81,11 +81,11 @@ export class QueryRef<T, V extends OperationVariables = EmptyObject> {
     return this.obsQuery.getCurrentResult();
   }
 
-  public getLastResult(): ApolloQueryResult<T> {
+  public getLastResult(): ApolloQueryResult<T> | undefined {
     return this.obsQuery.getLastResult();
   }
 
-  public getLastError(): ApolloError {
+  public getLastError(): ApolloError | undefined {
     return this.obsQuery.getLastError();
   }
 
@@ -110,6 +110,7 @@ export class QueryRef<T, V extends OperationVariables = EmptyObject> {
     // it should not inherit types from ObservableQuery
     return this.obsQuery.subscribeToMore(options as any);
   }
+
   public updateQuery(mapFn: (previousQueryResult: T, options: UpdateQueryOptions<V>) => T): void {
     return this.obsQuery.updateQuery(mapFn);
   }

--- a/packages/apollo-angular/src/query.ts
+++ b/packages/apollo-angular/src/query.ts
@@ -7,8 +7,8 @@ import { QueryRef } from './query-ref';
 import { EmptyObject, QueryOptionsAlone, WatchQueryOptionsAlone } from './types';
 
 @Injectable()
-export class Query<T = {}, V extends OperationVariables = EmptyObject> {
-  public readonly document: DocumentNode | TypedDocumentNode<T, V>;
+export abstract class Query<T = {}, V extends OperationVariables = EmptyObject> {
+  public abstract readonly document: DocumentNode | TypedDocumentNode<T, V>;
   public client = 'default';
 
   constructor(protected apollo: Apollo) {}

--- a/packages/apollo-angular/src/subscription.ts
+++ b/packages/apollo-angular/src/subscription.ts
@@ -1,7 +1,7 @@
 import type { DocumentNode } from 'graphql';
 import type { Observable } from 'rxjs';
 import { Injectable } from '@angular/core';
-import type { TypedDocumentNode } from '@apollo/client/core';
+import type { OperationVariables, TypedDocumentNode } from '@apollo/client/core';
 import { Apollo } from './apollo';
 import {
   EmptyObject,
@@ -11,8 +11,8 @@ import {
 } from './types';
 
 @Injectable()
-export class Subscription<T = any, V = EmptyObject> {
-  public readonly document: DocumentNode | TypedDocumentNode<T, V>;
+export abstract class Subscription<T = any, V extends OperationVariables = EmptyObject> {
+  public abstract readonly document: DocumentNode | TypedDocumentNode<T, V>;
   public client = 'default';
 
   constructor(protected apollo: Apollo) {}

--- a/packages/apollo-angular/src/types.ts
+++ b/packages/apollo-angular/src/types.ts
@@ -24,7 +24,7 @@ export interface ExtraSubscriptionOptions {
 }
 
 export type MutationResult<TData = any> = FetchResult<TData> & {
-  loading: boolean;
+  loading?: boolean;
 };
 
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;

--- a/packages/apollo-angular/src/utils.ts
+++ b/packages/apollo-angular/src/utils.ts
@@ -8,7 +8,7 @@ import type {
   FetchResult,
   ObservableQuery,
 } from '@apollo/client/core';
-import type { MutationResult } from './types';
+import { MutationResult } from './types';
 
 export function fromPromise<T>(promiseFn: () => Promise<T>): Observable<T> {
   return new Observable<T>(subscriber => {
@@ -79,12 +79,4 @@ export function fixObservable<T>(
 
 export function wrapWithZone<T>(obs: Observable<T>, ngZone: NgZone): Observable<T> {
   return obs.pipe(observeOn(new ZoneScheduler(ngZone)));
-}
-
-export function pickFlag<TFlags, K extends keyof TFlags>(
-  flags: TFlags | undefined,
-  flag: K,
-  defaultValue: TFlags[K],
-): TFlags[K] {
-  return flags && typeof flags[flag] !== 'undefined' ? flags[flag] : defaultValue;
 }

--- a/packages/apollo-angular/testing/tests/operation.spec.ts
+++ b/packages/apollo-angular/testing/tests/operation.spec.ts
@@ -32,7 +32,7 @@ describe('TestOperation', () => {
       done();
     });
 
-    mock.expectOne(testQuery).flush(null);
+    mock.expectOne(testQuery).flush(null!);
   });
 
   test('should accepts data for flush operation', done => {

--- a/packages/apollo-angular/tests/Apollo.spec.ts
+++ b/packages/apollo-angular/tests/Apollo.spec.ts
@@ -135,7 +135,7 @@ describe('Apollo', () => {
             } else if (calls > 2) {
               throw new Error('Called third time');
             }
-          } catch (e) {
+          } catch (e: any) {
             done.fail(e);
           }
         },
@@ -148,7 +148,7 @@ describe('Apollo', () => {
         obs.refetch(variables2).then(({ data }) => {
           try {
             expect(data).toMatchObject(data2);
-          } catch (e) {
+          } catch (e: any) {
             done.fail(e);
           }
         });
@@ -1029,7 +1029,7 @@ describe('Apollo', () => {
 
     apollo.removeClient();
 
-    expect(apollo.client).toBeUndefined();
+    expect(() => apollo.client).toThrow('Client has not been defined yet');
   });
 
   test('should remove named client', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,9 @@
     "experimentalDecorators": true,
     "noImplicitAny": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "noUnusedParameters": true,
+    "strictNullChecks": true,
+    "strict": true
   },
   "angularCompilerOptions": {
     "enableResourceInlining": true,


### PR DESCRIPTION
- `ApolloBase.client` throws an error if no client has been created
  beforehand. The behavior now matches the typing that always declared a
  client existed. In most cases, you should pass either `apolloOptions`
  or `apolloNamedOptions` to `Apollo.constructor` to create the
  client immediately upon construction.
- `ApolloBase.query()`, `ApolloBase.mutate()` and
  `ApolloBase.subscribe()` all have a new constraint on `V`. If you
  inherit from this class, you might need to adjust your typing.
- Classes that inherit `Query`, `Mutation` and `Subscription` must
  declare the `document` member. This requirement always existed at
  runtime but was not enforced at compile time until now. If you
  generated code, you have nothing to do.
- `QueryRef.getLastResult()` and `QueryRef.getLastError()` might return
  `undefined`. This was always the case, but was typed incorrectly until
  now.
- `pickFlag()` was dropped without any replacement.
- `createPersistedQueryLink()` requires options. This was always the
  case but was typed incorrectly until now.
