### PR TITLE
docs: graphql-ws instead of deprecated subscriptions-transport-ws

### DIFF
--- a/website/src/pages/docs/data/subscriptions.mdx
+++ b/website/src/pages/docs/data/subscriptions.mdx
@@ -56,7 +56,7 @@ The response sent to the client looks as follows:
 In the above example, the server is written to send a new result every time a comment is added on
 GitHunt for a specific repository. Note that the code above only defines the GraphQL subscription in
 the schema. Read [setting up subscriptions on the client](#client-setup) and
-[setting up GraphQL subscriptions for the server](https://www.apollographql.com/docs/graphql-subscriptions/)
+[setting up GraphQL subscriptions for the server](https://www.apollographql.com/docs/graphql-subscriptions)
 to learn how to add subscriptions to your app.
 
 ### When to Use Subscriptions
@@ -78,62 +78,73 @@ possible outside of some relatively experimental setups.
 
 Because subscriptions maintain a persistent connection, they can't use the default HTTP transport
 that Apollo Client uses for queries and mutations. Instead, Apollo Client subscriptions most
-commonly communicate over WebSocket, via the community-maintained
-[`subscriptions-transport-ws`](https://github.com/apollographql/subscriptions-transport-ws) library.
+commonly communicate over WebSocket.
+
+Install the community-maintained
+[`graphql-ws`](https://github.com/enisdenjo/graphql-ws) library.
+
+```sh
+npm install graphql-ws
+```
 
 Let's look at how to add support for this transport to Apollo Client.
 
 ```ts
-import { WebSocketLink } from '@apollo/client/link/ws';
+import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
+import { createClient } from "graphql-ws";
 
-const wsClient = new WebSocketLink({
-  uri: 'ws://localhost:5000/graphql',
-  options: {
-    reconnect: true,
-  },
-});
+const ws = new GraphQLWsLink(
+  createClient({
+    url: "ws://localhost:3000/graphql"
+  })
+);
 ```
 
 ```ts
-import { APOLLO_OPTIONS } from 'apollo-angular';
-import { HttpLink } from 'apollo-angular/http';
-import { ApolloClientOptions, split } from '@apollo/client/core';
-import { WebSocketLink } from '@apollo/client/link/ws';
-import { getMainDefinition } from '@apollo/client/utilities';
+import { type ApolloClientOptions, InMemoryCache, split } from "@apollo/client/core";
+import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
+import { getMainDefinition } from "@apollo/client/utilities";
+import { APOLLO_OPTIONS } from "apollo-angular";
+import { HttpLink } from "apollo-angular/http";
+import { Kind, OperationTypeNode } from "graphql";
+import { createClient } from "graphql-ws";
 
 @NgModule({
   providers: [
     {
       provide: APOLLO_OPTIONS,
-      useFactory(httpLink: HttpLink): ApolloClientOptions {
+      useFactory(httpLink: HttpLink): ApolloClientOptions<unknown> {
         // Create an http link:
         const http = httpLink.create({
           uri: 'http://localhost:3000/graphql',
         });
 
         // Create a WebSocket link:
-        const ws = new WebSocketLink({
-          uri: 'ws://localhost:5000/',
-          options: {
-            reconnect: true,
-          },
-        });
+        const ws = new GraphQLWsLink(
+          createClient({
+            url: "ws://localhost:3000/graphql"
+          })
+        );
 
-        // using the ability to split links, you can send data to each link
+        // Using the ability to split links, you can send data to each link
         // depending on what kind of operation is being sent
         const link = split(
-          // split based on operation type
+          // Split based on operation type
           ({ query }) => {
-            const { kind, operation } = getMainDefinition(query);
-            return kind === 'OperationDefinition' && operation === 'subscription';
-          },
-          ws,
-          http,
+              const definition = getMainDefinition(query);
+              return (
+                definition.kind === Kind.OPERATION_DEFINITION &&
+                definition.operation === OperationTypeNode.SUBSCRIPTION
+              );
+            },
+            ws,
+            http
         );
 
         return {
           link,
-          // ... options
+          cache: new InMemoryCache(),
+          // ... Options
         };
       },
       deps: [HttpLink],


### PR DESCRIPTION
### Checklist:

Reference to issue #1801

In the documentation, replace the deprecated `subscriptions-transport-ws` with `graphql-ws`.
Moreover, in `getMainDefinition`, first check `kind`, then `operation`, to avoid both runtime errors and _TypeScript_ errors.