### PR TITLE
Disable Renovate entirely

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>the-guild-org/shared-config:renovate", "schedule:quarterly"],
-  "automerge": true,
-  "packageRules": [
-    {
-      "groupName": "angular",
-      "matchPackagePrefixes": ["@angular", "@schematics"]
-    }
-  ]
+  "enabled": false
 }


### PR DESCRIPTION
Because it generates a ton of noises to merge PR, but it brings little value for this specific project.

And because `automerge` could reduce the noise, but it then merges broken builds as seen in https://github.com/kamilkisiela/apollo-angular/pull/2267, which is a huge no-go.

And because I don't have time, nor interest, to figure out a better configuration than that.

