### PR TITLE
Use import from @apollo/client/core instead of @apollo/client

### DIFF
--- a/.changeset/red-foxes-listen.md
+++ b/.changeset/red-foxes-listen.md
@@ -1,0 +1,5 @@
+---
+"apollo-angular": patch
+---
+
+Don't require a dependency on React

--- a/packages/apollo-angular/src/apollo.ts
+++ b/packages/apollo-angular/src/apollo.ts
@@ -8,7 +8,7 @@ import type {
   OperationVariables,
   QueryOptions,
   SubscriptionOptions,
-  WatchFragmentResult
+  WatchFragmentResult,
 } from '@apollo/client/core';
 import { ApolloClient } from '@apollo/client/core';
 import { QueryRef } from './query-ref';

--- a/packages/apollo-angular/src/apollo.ts
+++ b/packages/apollo-angular/src/apollo.ts
@@ -1,6 +1,5 @@
 import { from, Observable } from 'rxjs';
 import { Inject, Injectable, NgZone, Optional } from '@angular/core';
-import type { WatchFragmentResult } from '@apollo/client';
 import type {
   ApolloClientOptions,
   ApolloQueryResult,
@@ -9,6 +8,7 @@ import type {
   OperationVariables,
   QueryOptions,
   SubscriptionOptions,
+  WatchFragmentResult
 } from '@apollo/client/core';
 import { ApolloClient } from '@apollo/client/core';
 import { QueryRef } from './query-ref';


### PR DESCRIPTION
Version 7.1.1 introduces a import from @apollo/client, that causes typescript to need a reference from React. It needs to be an import from @apollo/client/core, like all the other imports.

### Checklist:
- [ x ] If this PR is a new feature, please reference a discussion where a consensus about the design
      was reached (not necessary for small changes)
- [ x ] Make sure all the significant new logic is covered by tests
