### PR TITLE
Smaller bundle for `gql`

### DIFF
--- a/.changeset/dirty-seals-heal.md
+++ b/.changeset/dirty-seals-heal.md
@@ -1,0 +1,5 @@
+---
+'apollo-angular': patch
+---
+
+Smaller bundle for `gql`

--- a/packages/apollo-angular/src/gql.ts
+++ b/packages/apollo-angular/src/gql.ts
@@ -1,11 +1,9 @@
 import { gql as gqlTag, TypedDocumentNode } from '@apollo/client/core';
 
-function typedGQLTag<Result, Variables>(
+const typedGQLTag: <Result, Variables>(
   literals: ReadonlyArray<string> | Readonly<string>,
   ...placeholders: any[]
-): TypedDocumentNode<Result, Variables> {
-  return gqlTag(literals, ...placeholders);
-}
+) => TypedDocumentNode<Result, Variables> = gqlTag;
 
 export const gql = typedGQLTag;
 export const graphql = typedGQLTag;


### PR DESCRIPTION
Casting, instead of wrapping, the existing `gql` function, save ~60 bytes, and avoid an extra function call at runtime

### Checklist:

- [ ] If this PR is a new feature, please reference a discussion where a consensus about the design
      was reached (not necessary for small changes)
- [ ] Make sure all the significant new logic is covered by tests
