### PR TITLE
Export MutationOptionsAlone, QueryOptionsAlone, SubscriptionOptionsAl…

### DIFF
--- a/.changeset/curly-rivers-complain.md
+++ b/.changeset/curly-rivers-complain.md
@@ -1,0 +1,6 @@
+---
+'apollo-angular': patch
+---
+
+Export MutationOptionsAlone, QueryOptionsAlone, SubscriptionOptionsAlone, WatchQueryOptionsAlone
+from 'apollo-angular'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,6 +152,7 @@ jobs:
 
       - name: Setup E2E tests
         run: |
+          sudo apt-get update
           sudo apt-get install libgtk2.0-0t64 libgtk-3-0t64 libgbm-dev libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth xvfb
           (cd testapp && yarn add -D cypress-fail-on-console-error)
 

--- a/packages/apollo-angular/src/index.ts
+++ b/packages/apollo-angular/src/index.ts
@@ -7,13 +7,17 @@ export { Mutation } from './mutation';
 export { Subscription } from './subscription';
 export { APOLLO_OPTIONS, APOLLO_NAMED_OPTIONS, APOLLO_FLAGS } from './tokens';
 export type {
-  NamedOptions,
-  SubscriptionResult,
-  WatchQueryOptions,
   ExtraSubscriptionOptions,
-  MutationResult,
   Flags,
-  VariablesOf,
+  MutationOptionsAlone,
+  MutationResult,
+  NamedOptions,
+  QueryOptionsAlone,
   ResultOf,
+  SubscriptionOptionsAlone,
+  SubscriptionResult,
+  VariablesOf,
+  WatchQueryOptions,
+  WatchQueryOptionsAlone,
 } from './types';
 export { gql, graphql } from './gql';


### PR DESCRIPTION
…one, WatchQueryOptionsAlone from  'apollo-angular'

Fixes #1756
Fixes #2335

### Checklist:

- [ ] If this PR is a new feature, please reference a discussion where a consensus about the design
      was reached (not necessary for small changes)
- [ ] Make sure all the significant new logic is covered by tests
