### PR TITLE
`FormattedExecutionResult` instead of `ExecutionResult`

### DIFF
--- a/.changeset/stale-penguins-remember.md
+++ b/.changeset/stale-penguins-remember.md
@@ -1,0 +1,5 @@
+---
+'apollo-angular': patch
+---
+
+`FormattedExecutionResult` instead of `ExecutionResult`

--- a/packages/apollo-angular/testing/src/operation.ts
+++ b/packages/apollo-angular/testing/src/operation.ts
@@ -1,4 +1,4 @@
-import { ExecutionResult, GraphQLError, Kind, OperationTypeNode } from 'graphql';
+import { FormattedExecutionResult, GraphQLError, Kind, OperationTypeNode } from 'graphql';
 import { Observer } from 'rxjs';
 import { ApolloError, FetchResult, Operation as LinkOperation } from '@apollo/client/core';
 import { getMainDefinition } from '@apollo/client/utilities';
@@ -15,7 +15,7 @@ export class TestOperation<T = { [key: string]: any }> {
     private readonly observer: Observer<FetchResult<T>>,
   ) {}
 
-  public flush(result: ExecutionResult<T> | ApolloError): void {
+  public flush(result: FormattedExecutionResult<T> | ApolloError): void {
     if (isApolloError(result)) {
       this.observer.error(result);
     } else {


### PR DESCRIPTION
According to https://github.com/apollographql/apollo-client/pull/11789

